### PR TITLE
Surround variable references with double quotes so spaces in paths are handled properly

### DIFF
--- a/gocryptfs-ui
+++ b/gocryptfs-ui
@@ -24,7 +24,7 @@
 ###############################################################################
 
 usage() {
-    echo "Usage: $(basename $0) [-options] source_enc_dir target_mount_dir"
+    echo "Usage: $(basename "$0") [-options] source_enc_dir target_mount_dir"
     echo "GUI utility to mount source_enc_dir to target_mount_dir."
     echo "If target already mounted then it will be unmounted instead."
     echo "Options:"
@@ -53,8 +53,8 @@ if [[ $# -ne 2 ]]; then
 fi
 
 # Read source and target dirs. Make absolute path.
-src=$(readlink -f $1)
-tgt=$(readlink -f $2)
+src=$(readlink -f "$1")
+tgt=$(readlink -f "$2")
 
 # Check usage
 if [[ -z $src || -z $tgt  ]]; then
@@ -78,7 +78,7 @@ gui() {
 	--text="$text" --modal $args
 }
 
-if ! type $PROG &>/dev/null; then
+if ! type "$PROG" &>/dev/null; then
     gui Mount error \
     "Sorry, $PROG is not installed.\n\nInstall it via your package manager."
     exit 1
@@ -108,11 +108,11 @@ fi
 
 open-dir-gui() {
     local dir="$1"
-    xdg-open $dir &>/dev/null &
+    xdg-open "$dir" &>/dev/null &
 }
 
 # Mount the directory. Check first that this is the correct type of filesystem
-if ! $PROG -info "$src" &>/dev/null; then
+if ! "$PROG" -info "$src" &>/dev/null; then
     gui Mount error \
     "$src does not exist or is not an $PROG filesystem.\nCreate it manually with $PROG. E.g. Run the following and answer the prompts:\n\nmkdir -p $src; $PROG -init $src\n\nSee man gocryptfs for more options and details."
     exit 1
@@ -134,7 +134,7 @@ while true; do
     fi
 
     # Give password to $PROG and mount the file system
-    res=$($PROG -passfile $tmp $MINS "$src" "$tgt" 2>&1)
+    res=$("$PROG" -passfile $tmp $MINS "$src" "$tgt" 2>&1)
 
     # Check for error (typically a bad password)
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
Hello Mark, I was thinking of writing a quick GUI wrapper for gocryptfs but thought ‘maybe someone has already done something similar’ and found your script.

I quickly ran into trouble when `source_enc_dir` or `target_mount_dir` contained spaces though. This led me to take a closer look and do an ultimate breaking test by adding a space to the script file name, script path and gocryptfs path, i.e. I set PROG to `/data/foo bar/gocryptfs/gocryptfs` and invoked the script with `"/data/foo bar/gocryptfs/gocryptfs-ui wrapper" "private files" "private files mount"`

Here are the fixes needed to handle this properly. I would strongly suggest always using double quotes when referencing variables in a Bash script, unless this doesn't work as intended, like with your use of $args in the gui function.

Your setup script (`gocryptfs-ui-setup`) looks truly scary to me with all the `rm -rfv $SOMEDIR$SUBDIR/$NAME` lines. Imagine if one of those (accidentally) ends up containing spaces, you might delete whole system directories you didn't mean to target. It wouldn't be a bad idea to add quotation marks there as well.

Cheers!