### PR TITLE
Surround $tmp references with double quotes to properly handle spaces

### DIFF
--- a/gocryptfs-ui
+++ b/gocryptfs-ui
@@ -121,7 +121,7 @@ fi
 # Create target dir if it doesn't exist
 mkdir -p "$tgt" &>/dev/null
 
-trap 'rm -rf $tmp' EXIT
+trap 'rm -f "$tmp"' EXIT
 tmp=$(mktemp)
 
 # Loop on user entry for password ..
@@ -129,12 +129,12 @@ mounted=0
 while true; do
 
     # Get password from user
-    if ! gui Mount entry "Mount $src to $tgt\n\nWhat is the password?" >$tmp; then
+    if ! gui Mount entry "Mount $src to $tgt\n\nWhat is the password?" >"$tmp"; then
 	break
     fi
 
     # Give password to $PROG and mount the file system
-    res=$("$PROG" -passfile $tmp $MINS "$src" "$tgt" 2>&1)
+    res=$("$PROG" -passfile "$tmp" $MINS "$src" "$tgt" 2>&1)
 
     # Check for error (typically a bad password)
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
I wanted to touch as little code as possible last time, but couldn't help but spot a potential data loss disaster today that will probably never happen but shouldn't be able to happen anyway. Due to another set of missing quotation marks.

`mktemp` uses "$TMPDIR  if set, else /tmp". So if gocryptfs-ui runs on a system with a custom $TMPDIR that contains spaces, and say `TMPDIR="/home/user/documents temp"`, it will run e.g. `rm -rf /home/user/documents temp/tmp.4tBsF40QTV` on exit, which—thanks to the unnecessary `-r`—will remove the user's `documents` folder recursively, if it exists (alongside `./temp/tmp.4tBsF40QTV`, which probably doesn't exist).

Spaces, don't underestimate them.

I added quotes and removed the unnecessary `-r`.