### PR TITLE
Don't write plain text password to temporary file

### DIFF
--- a/gocryptfs-ui
+++ b/gocryptfs-ui
@@ -121,20 +121,17 @@ fi
 # Create target dir if it doesn't exist
 mkdir -p "$tgt" &>/dev/null
 
-trap 'rm -f "$tmp"' EXIT
-tmp="$(mktemp)"
-
 # Loop on user entry for password ..
 mounted=0
 while true; do
 
     # Get password from user
-    if ! gui Mount entry "Mount $src to $tgt\n\nWhat is the password?" >"$tmp"; then
+    if ! password=$(gui Mount entry "Mount $src to $tgt\n\nWhat is the password?"); then
 	break
     fi
 
     # Give password to $PROG and mount the file system
-    res=$("$PROG" -passfile "$tmp" $MINS "$src" "$tgt" 2>&1)
+    res=$("$PROG" -passfile <(printf "$password") $MINS "$src" "$tgt" 2>&1)
 
     # Check for error (typically a bad password)
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
It's never a good idea to write a plain text password to disk, where it may persist in case of a crash or power outage, or be recovered later.

Instead, we can simply store the password in memory with a variable:
`password=$(gui Mount entry "Mount $src to $tgt\n\nWhat is the password?")`

Then pass it to gocryptfs with process substitution:
`"$PROG" -passfile <(printf "$password") $MINS "$src" "$tgt"`

Resulting in a process command line like:
`gocryptfs -fg -notifypid=2552373 -passfile /dev/fd/63 /path/to/crypt /path/to/mnt`

Where `/dev/fd/63` is the temporary file descriptor that was used in the process substitution to pass the password to gocryptfs. All in memory, no real file storing the password was used, and the command line still doesn't expose the password.

Alternatively, you could use gocryptfs with the `-extpass` option, and have it retrieve the password through zenity directly, but this doesn't integrate with your current approach of using the intermediate gui() function.