### PR TITLE
Fix password piping to grcryptfs process

### DIFF
--- a/gocryptfs-ui
+++ b/gocryptfs-ui
@@ -131,7 +131,7 @@ while true; do
     fi
 
     # Give password to $PROG and mount the file system
-    res=$("$PROG" -passfile <(printf "$password") $MINS "$src" "$tgt" 2>&1)
+    res=$("$PROG" -passfile <(printf %s "$password") $MINS "$src" "$tgt" 2>&1)
 
     # Check for error (typically a bad password)
     if [[ $? -eq 0 ]]; then


### PR DESCRIPTION
The printf command which pipes the password to gocryptfs, has the password variable as format argument. This lets passwords with a %-character followed by the appropriate character be interpreted as format specification. For example: foo%d will be written as foo0 by printf.  Inserting %s as format string and the password variable as its argument will ensure the correct printf output.